### PR TITLE
Fix some extra ligature characters

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -38,9 +38,9 @@ def replace_weird_characters(text):
         "ﬁ": "fi",
         "ﬂ": "fl",
         "ﬃ": "ffi",
-        "ﬄ": "ffl"
+        "ﬄ": "ffl",
     }
-    for key in replacement_dict:
+    for key in replacement_dict.keys():
         if key in text:
             text = text.replace(key, replacement_dict[key])
     return text

--- a/utils.py
+++ b/utils.py
@@ -32,7 +32,10 @@ def get_client(domain, client_id, client_secret):
 
 def replace_weird_characters(text):
     """sometimes some wierd unicode characters appear - lets just replace them for now and care about it later™"""
-    text = text.replace("�", "ti")
+    replacementDict = {"�":"ti", "ﬀ":"ff", "ﬁ": "fi", "ﬂ": "fl", "ﬃ": "ffi", "ﬄ": "ffl"}
+    for key in replacementDict.keys():
+        if key in text:
+            text = text.replace(key, replacementDict[key])
     return text
 
 

--- a/utils.py
+++ b/utils.py
@@ -32,10 +32,17 @@ def get_client(domain, client_id, client_secret):
 
 def replace_weird_characters(text):
     """sometimes some wierd unicode characters appear - lets just replace them for now and care about it later™"""
-    replacementDict = {"�":"ti", "ﬀ":"ff", "ﬁ": "fi", "ﬂ": "fl", "ﬃ": "ffi", "ﬄ": "ffl"}
-    for key in replacementDict.keys():
+    replacement_dict = {
+        "�": "ti",
+        "ﬀ": "ff",
+        "ﬁ": "fi",
+        "ﬂ": "fl",
+        "ﬃ": "ffi",
+        "ﬄ": "ffl"
+    }
+    for key in replacement_dict:
         if key in text:
-            text = text.replace(key, replacementDict[key])
+            text = text.replace(key, replacement_dict[key])
     return text
 
 


### PR DESCRIPTION
Pdf documents can contain ligatures. These are combinations of narrow symbols into a combined symbol. Unfortunately, ,,ti`` has no symbol when copying from a PDF so the default replacement character � (EF BF BD) is used. 